### PR TITLE
Changes to simplify the usage of build requires

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -93,16 +93,19 @@ class LibiconvConan(ConanFile):
 
     def build(self):
         if self.settings.os == "Windows":
-            cygwin_bin = self.deps_env_info['cygwin_installer'].CYGWIN_BIN
-            with tools.environment_append({'PATH': [cygwin_bin],
-                                           'CONAN_BASH_PATH': '%s/bash.exe' % cygwin_bin}):
-                if self.is_msvc:
-                    with tools.vcvars(self.settings):
-                        self.build_autotools()
-                elif self.is_mingw:
+            if tools.os_info.detect_windows_subsystem() not in ("cygwin", "msys2"):
+                raise Exception("This recipe needs a Windows Subsystem to be compiled. "
+                                "You can specify a build_require to:"
+                                " 'msys2_installer/latest@bincrafters/stable' or"
+                                " 'cygwin_installer/2.9.0@bincrafters/stable' or"
+                                " put in the PATH your own installation")
+            if self.is_msvc:
+                with tools.vcvars(self.settings):
                     self.build_autotools()
-                else:
-                    raise Exception("unsupported build")
+            elif self.is_mingw:
+                self.build_autotools()
+            else:
+                raise Exception("unsupported build")
         else:
             self.build_autotools()
 


### PR DESCRIPTION
It's better to raise an exception if the windows subsystem is not detected.

I've tested it in my windows environment

## default profile (no windows subsystem):

```python
C:\Users\pedro\.conan\profiles
λ cat default
[settings]
os=Windows
os_build=Windows
arch=x86_64
arch_build=x86_64
compiler=Visual Studio
compiler.version=15
build_type=Release
[options]
[build_requires]
[env]
```
Raise exception:

```bash
E:\git\conan\conan-community\review_libraries\conan-libiconv (fix_the_way_of_using_build_requires -> origin)
(conan1.1.0) λ conan create . pedro/test
libiconv/1.15@pedro/test: Exporting package recipe
libiconv/1.15@pedro/test: A new conanfile.py version was exported
libiconv/1.15@pedro/test: Folder: C:\Users\pedro\.conan\data\libiconv\1.15\pedro\test\export
libiconv/1.15@pedro/test (test package): Installing E:\git\conan\conan-community\review_libraries\conan-libiconv\test_package\conanfile.py Requirements
    libiconv/1.15@pedro/test from local cache
Packages
    libiconv/1.15@pedro/test:ce1f8ff23addde793223a2a82ed7fe355c57a589

libiconv/1.15@pedro/test: WARN: Forced build from source
libiconv/1.15@pedro/test: Building your package in C:\Users\pedro\.conan\data\libiconv\1.15\pedro\test\build\ce1f8ff23addde793223a2a82ed7fe355c57a589
libiconv/1.15@pedro/test: Configuring sources in C:\Users\pedro\.conan\data\libiconv\1.15\pedro\test\source
[==================================================] 5.0MB/5.0MB
libiconv/1.15@pedro/test: Copying sources to build folder
libiconv/1.15@pedro/test: Generator txt created conanbuildinfo.txt
libiconv/1.15@pedro/test: Calling build()
libiconv/1.15@pedro/test:
libiconv/1.15@pedro/test: ERROR: Package 'ce1f8ff23addde793223a2a82ed7fe355c57a589' build failed
libiconv/1.15@pedro/test: WARN: Build folder C:\Users\pedro\.conan\data\libiconv\1.15\pedro\test\build\ce1f8ff23addde793223a2a82ed7fe355c57a589
ERROR: libiconv/1.15@pedro/test: Error in build() method, line 97
        raise Exception("This recipe needs a Windows Subsystem to be compiled. "
        Exception: This recipe needs a Windows Subsystem to be compiled. You can specify a build_require to: 'msys2_installer/latest@bincrafters/stable' or 'cygwin_installer/2.9.0@bincrafters/stable' or put in the PATH your own installation
```

## ``cygwin_build_require`` profile:

```python
C:\Users\pedro\.conan\profiles
λ cat cygwin_build_require
include(default)
[build_requires]
cygwin_installer/2.9.0@bincrafters/stable
```

Works with user home without spaces in path 😉 

```bash
(conan1.1.0) λ conan create . pedro/test -pr=cygwin_build_require
...
         nvoker' uiAccess='false'" /manifest:embed /PDB:"E:/git/conan/conan-community/review_libraries/conan-libiconv/test_package/build/e
         6348560a0acdcc2ded7a23613e02c87fd1511e7/bin/test_package.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"E:/git/
         conan/conan-community/review_libraries/conan-libiconv/test_package/build/e6348560a0acdcc2ded7a23613e02c87fd1511e7/lib/test_packag
         e.lib" /MACHINE:X64  /machine:x64 test_package.dir\Release\test_package.obj
         test_package.vcxproj -> E:\git\conan\conan-community\review_libraries\conan-libiconv\test_package\build\e6348560a0acdcc2ded7a2361
         3e02c87fd1511e7\bin\test_package.exe
       FinalizeBuildStatus:
         Deleting file "test_package.dir\Release\test_package.tlog\unsuccessfulbuild".
         Touching "test_package.dir\Release\test_package.tlog\test_package.lastbuildstate".
     3>Done Building Project "E:\git\conan\conan-community\review_libraries\conan-libiconv\test_package\build\e6348560a0acdcc2ded7a23613e0
       2c87fd1511e7\test_package.vcxproj" (default targets).
     1>PrepareForBuild:
         Creating directory "x64\Release\ALL_BUILD\".
         Creating directory "x64\Release\ALL_BUILD\ALL_BUILD.tlog\".
       InitializeBuildStatus:
         Creating "x64\Release\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
       CustomBuild:
         Building Custom Rule E:/git/conan/conan-community/review_libraries/conan-libiconv/test_package/CMakeLists.txt
         CMake does not need to re-run because E:/git/conan/conan-community/review_libraries/conan-libiconv/test_package/build/e6348560a0a
         cdcc2ded7a23613e02c87fd1511e7/CMakeFiles/generate.stamp is up-to-date.
       FinalizeBuildStatus:
         Deleting file "x64\Release\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild".
         Touching "x64\Release\ALL_BUILD\ALL_BUILD.tlog\ALL_BUILD.lastbuildstate".
     1>Done Building Project "E:\git\conan\conan-community\review_libraries\conan-libiconv\test_package\build\e6348560a0acdcc2ded7a23613e0
       2c87fd1511e7\ALL_BUILD.vcxproj" (default targets).

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:03.23
libiconv/1.15@pedro/test (test package): Running test()
retval 0 99 105 97 111
```

## ``msys2_build_require`` profile:

```python
λ cat msys2_build_require
include(default)

[build_requires]
msys2_installer/latest@bincrafters/stable
```

Works with user home without spaces in path:

```bash
(conan1.1.0) λ conan create . pedro/test2 -pr=msys2_build_require
...
       InitializeBuildStatus:
         Creating "x64\Release\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
       CustomBuild:
         Building Custom Rule E:/git/conan/conan-community/review_libraries/conan-libiconv/test_package/CMakeLists.txt
         CMake does not need to re-run because E:/git/conan/conan-community/review_libraries/conan-libiconv/test_package/build/2a058a4b656
         800ceb17070dd210b8cef2322dadf/CMakeFiles/generate.stamp is up-to-date.
       FinalizeBuildStatus:
         Deleting file "x64\Release\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild".
         Touching "x64\Release\ALL_BUILD\ALL_BUILD.tlog\ALL_BUILD.lastbuildstate".
     1>Done Building Project "E:\git\conan\conan-community\review_libraries\conan-libiconv\test_package\build\2a058a4b656800ceb17070dd210b
       8cef2322dadf\ALL_BUILD.vcxproj" (default targets).

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.65
libiconv/1.15@pedro/test2 (test package): Running test()
retval 0 99 105 97 111
```

It should also work in your CI.

Credits to @lasote 
