### PR TITLE
Remove fPIC for Windows to resolve check list warning in review

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,6 +16,7 @@ class LibiconvConan(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = "shared=False", "fPIC=True"
     archive_name = "{0}-{1}".format(name, version)
+    short_paths = True
 
     @property
     def is_mingw(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,6 +29,10 @@ class LibiconvConan(ConanFile):
     def configure(self):
         del self.settings.compiler.libcxx
 
+    def config_options(self):
+        if self.settings.os == 'Windows':
+            del self.options.fPIC
+
     def source(self):
         source_url = "https://ftp.gnu.org/gnu/libiconv"
         tools.get("{0}/{1}.tar.gz".format(source_url, self.archive_name))
@@ -51,7 +55,9 @@ class LibiconvConan(ConanFile):
                 rc = "windres --target=pe-x86-64"
 
         env_build = AutoToolsBuildEnvironment(self, win_bash=win_bash)
-        env_build.fpic = self.options.fPIC
+
+        if self.settings.os != "Windows":
+            env_build.fpic = self.options.fPIC
 
         configure_args = ['--prefix=%s' % prefix]
         if self.options.shared:

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,8 +92,16 @@ class LibiconvConan(ConanFile):
                 env_build.make()
                 env_build.make(args=["install"])
 
+    def fix_windows_permissions(self, folder):
+        """ grant ACL permissions so Cygwin has necessary access rights """
+        if not os.path.isdir(folder):
+            os.makedirs(folder)
+        self.run('cacls %s /T /E /G "%s\\%s":F' % (folder, os.environ['USERDOMAIN'], os.environ['USERNAME']))
+
     def build(self):
         if self.settings.os == "Windows":
+            self.fix_windows_permissions(self.build_folder)
+            self.fix_windows_permissions(self.package_folder)
             if tools.os_info.detect_windows_subsystem() not in ("cygwin", "msys2"):
                 raise Exception("This recipe needs a Windows Subsystem to be compiled. "
                                 "You can specify a build_require to:"

--- a/conanfile.py
+++ b/conanfile.py
@@ -93,16 +93,19 @@ class LibiconvConan(ConanFile):
 
     def build(self):
         if self.settings.os == "Windows":
-            cygwin_bin = self.deps_env_info['cygwin_installer'].CYGWIN_BIN
-            with tools.environment_append({'PATH': [cygwin_bin],
-                                           'CONAN_BASH_PATH': '%s/bash.exe' % cygwin_bin}):
-                if self.is_msvc:
-                    with tools.vcvars(self.settings):
-                        self.build_autotools()
-                elif self.is_mingw:
+            if tools.os_info.detect_windows_subsystem() not in ("cygwin", "msys2"):
+                raise Exception("This recipe needs a Windows Subsystem to be compiled. "
+                                "You can specify a build_require to:"
+                                " 'msys2_installer/latest@bincrafters/stable' or"
+                                " 'cygwin_installer/2.9.0@bincrafters/stable' or"
+                                " put in the PATH your own installation")
+            if self.is_msvc:
+                with tools.vcvars(self.settings):
                     self.build_autotools()
-                else:
-                    raise Exception("unsupported build")
+            elif self.is_mingw:
+                self.build_autotools()
+            else:
+                raise Exception("unsupported build")
         else:
             self.build_autotools()
 


### PR DESCRIPTION
This is to resolve the last warning in our check tool before including it into ```conan-center```.

![screenshot 2018-03-02 11 27 36](https://user-images.githubusercontent.com/471109/36897026-d2994f6c-1e0c-11e8-95de-118c9ac5d921.png)

The ```conan-team``` is suggesting as **best practice** removing the fPIC option for Windows in ```config_options(self)``` method. 

References https://github.com/bincrafters/community/issues/143